### PR TITLE
Disable RuboCop checks for trailing whitespace and string literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,4 +5,9 @@ inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 #
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
 # Layout/SpaceInsideArrayLiteralBrackets:
-#   Enabled: false
+
+Layout/TrailingWhitespace:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false


### PR DESCRIPTION
robucopを無効化しました