### PR TITLE
feat: implement timeline tab UI with active state styling

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -105,4 +105,37 @@
         color: rgb(88, 88, 88);
         text-decoration: none;
     }
+
+    .timeline-tabs {
+        display: flex;
+        justify-content: space-between;
+    }
+
+    .timeline-tabs__tab {
+        position: relative;
+        width: 50%;
+        height: 50px;
+        line-height: 50px;
+        display: block;
+        color: black;
+        text-align: center;
+        text-decoration: none;
+        border: 1px solid rgb(195, 195, 195);
+    }
+    
+    .timeline-tabs__tab:hover {
+        opacity: 0.7;
+        transition: opacity 0.2s ease;
+    }
+
+    .timeline-tabs__tab.is-active::after {
+        content: "";
+        position: absolute;
+        bottom: 0;
+        left: 25%;
+        width: 50%;
+        height: 4px;
+        background-color:rgb(195, 195, 195);
+        border-radius: 2px;
+    }
 }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -27,6 +27,15 @@ class PostsController < ApplicationController
     end
   end
 
+  def following
+    @post = Post.new
+    @posts = Post.includes(:user)
+               .where(user_id: current_user.follow_users.select(:id))  # フォロー中ユーザーだけ
+               .order(created_at: :desc)
+               .paginate(page: params[:page])
+    render :index
+  end
+
   private
 
   def post_params

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -4,6 +4,10 @@
     %div.post-area__header
       %h1.post-area__title 投稿一覧
 
+    .timeline-tabs
+      = link_to 'すべての投稿', posts_path, class: "timeline-tabs__tab timeline-tabs__tab--all#{' is-active' if current_page?(posts_path)}"
+      = link_to 'フォロー中', posts_following_path, class: "timeline-tabs__tab timeline-tabs__tab--following#{' is-active' if current_page?(posts_following_path)}"
+
     %div.post-area__form-container
       = form_with model: @post, local: true do |f|
         = f.text_area :content, class: "post-area__textarea", placeholder: "投稿内容を入力", maxlength: 140

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   get "follows/destroy"
   devise_for :users, controllers: { registrations: 'users/registrations' }
   resources :posts, only: [:index, :create] 
+  get 'posts/following', to: 'posts#following'
   root to: 'posts#index'
 
   resources :users, only: [:show]


### PR DESCRIPTION
タイムラインの切り替えUIを実装しました。
「すべての投稿」「フォロー中」の2つのタブを追加
current_page? を使って現在のタブに is-active クラスを付与
擬似要素（::after）を使って、選択中タブに下線を表示
hover時の透明効果（opacity）を追加