### PR TITLE
fix(ci): correct DATABASE_URL host from localhost to db for CI enviro…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
     env:
       RAILS_ENV: test
-      DATABASE_URL: postgres://postgres:password@localhost:5432/mini_blog_test
+      DATABASE_URL: postgres://postgres:password@db:5432/mini_blog_test
 
     steps:
       - uses: actions/checkout@v3

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,6 +14,9 @@ development:
 test:
   <<: *default
   database: mini_blog_test
+  username: postgres
+  password: password
+  host: db
 
 production:
   <<: *default

--- a/config/database.yml.github_actions
+++ b/config/database.yml.github_actions
@@ -4,4 +4,4 @@ test:
   database: mini_blog_test
   username: postgres
   password: password
-  host: localhost
+  host: db


### PR DESCRIPTION
…nment

テスト用データベースに接続できなかったCI環境の問題を修正しました。
GitHub Actionsのservices定義に合わせて、DATABASE_URLのホスト名を`localhost`から`db`に変更しました。